### PR TITLE
Add a script for running docker inside wolf

### DIFF
--- a/src/Dockerfile_base
+++ b/src/Dockerfile_base
@@ -72,3 +72,7 @@ ENTRYPOINT /usr/local/share/slurm_gcp_docker/src/docker_entrypoint_controller.sh
 #
 # set Slurm environment
 ENV SLURM_CONF "/mnt/nfs/clust_conf/slurm/slurm.conf"
+
+#
+# update PATH environment
+ENV PATH="/usr/local/share/slurm_gcp_docker/src/docker_bin:${PATH}"

--- a/src/docker_bin/wo_docker_run
+++ b/src/docker_bin/wo_docker_run
@@ -24,17 +24,22 @@ rm $WO_CONTAINER_NAME_FILE
 docker run --pid host --cidfile $WO_CONTAINER_NAME_FILE $@ < <(cat) &
 
 ## Wait until the CID file is created or the process stopped (by accident!)
+sleep 0.1
 while true; do
-    ## Check file
+    sleep 0.01
+    ## Check file and it is not EMPTY !!!
     if [ -f $WO_CONTAINER_NAME_FILE ]; then
-        break
+        if [ "`cat $WO_CONTAINER_NAME_FILE`" != "" ]; then
+            break
+        #else
+        #    echo I checked $WO_CONTAINER_NAME_FILE once
+        fi
     fi
     ## Check accidents
     if ! kill -0 $!; then
         wait $!
         exit $?
     fi
-    sleep 0.0001
 done
 
 ## Read out the container id
@@ -49,7 +54,7 @@ WO_CONTAINER_PID=`docker inspect -f '{{ .State.Pid }}' $WO_CONTAINER_NAME`
 if [ "$WO_CONTAINER_PID" != 0 ]; then
     ## Classify the container process (and all of it's children)
     ## to the Slurm's cgroups assigned to the job
- 
+
     # Set the container process free from the docker cgroups
     cgclassify -g blkio,net_cls,devices,cpuacct,cpu:/ $WO_CONTAINER_PID
 

--- a/src/docker_bin/wo_docker_run
+++ b/src/docker_bin/wo_docker_run
@@ -41,7 +41,7 @@ done
 WO_CONTAINER_NAME=`cat $WO_CONTAINER_NAME_FILE`
 
 ## Get the container PID
-WO_CONTAINER_PID=`docker inspect -f '{{ .State.Pid }}' $WO_DOCKER_CONTAINER_NAME`
+WO_CONTAINER_PID=`docker inspect -f '{{ .State.Pid }}' $WO_CONTAINER_NAME`
 
 ## There is a chance that $WO_CONTAINER_PID is zero if the
 ## container has stopped before `docker inspect`, in this case,

--- a/src/docker_bin/wo_docker_run
+++ b/src/docker_bin/wo_docker_run
@@ -4,12 +4,8 @@ set -e
 
 ## Argument checks.
 for arg in "$@"; do
-    if [ "$arg" = "--detach" ] || [ "$arg" = "-d" ]; then
-        echo "Should not give '--detach' argument to $0" >&2
-        exit 1
-    fi
-    if [ "$arg" = "--rm" ]; then
-        echo "Should not give '--rm' argument to $0" >&2
+    if [ "$arg" = "--cidfile" ]; then
+        echo "Should not give '--cidfile' argument to $0" >&2
         exit 1
     fi
 done
@@ -18,13 +14,34 @@ if [ "$SLURM_JOB_ID" = "" ]; then
     exit 1
 fi
 
-## Start running the container in detach mode.
+## File to store container name, remove it first, then
+## check its existence after docker run.
+WO_CONTAINER_NAME_FILE=`mktemp --suffix .wo_docker_run.cid`
+rm $WO_CONTAINER_NAME_FILE
+
+## Start running the container in background, with STDIN from this script.
 ## Also use --pid=host for protecting mental health.
-WO_CONTAINER_NAME=`docker run -d --pid host $@`
+docker run --pid host --cidfile $WO_CONTAINER_NAME_FILE $@ < <(cat) &
+
+## Wait until the CID file is created or the process stopped (by accident!)
+while true; do
+    ## Check file
+    if [ -f $WO_CONTAINER_NAME_FILE ]; then
+        break
+    fi
+    ## Check accidents
+    if ! kill -0 $!; then
+        wait $!
+        exit $?
+    fi
+    sleep 0.0001
+done
+
+## Read out the container id
+WO_CONTAINER_NAME=`cat $WO_CONTAINER_NAME_FILE`
 
 ## Get the container PID
 WO_CONTAINER_PID=`docker inspect -f '{{ .State.Pid }}' $WO_DOCKER_CONTAINER_NAME`
-
 
 ## There is a chance that $WO_CONTAINER_PID is zero if the
 ## container has stopped before `docker inspect`, in this case,
@@ -44,11 +61,5 @@ if [ "$WO_CONTAINER_PID" != 0 ]; then
     cgclassify -g memory,cpuset,freezer:/slurm/uid_$UID/job_$SLURM_JOB_ID/step_batch $(pgrep -P $WO_CONTAINER_PID)
 fi
 
-## Wait for the container
-docker wait $WO_CONTAINER_NAME
-
-## Output the logs
-docker logs $WO_CONTAINER_NAME
-
-## Finally remove the container
-docker rm $WO_CONTAINER_NAME
+## Wait for docker run
+wait $!

--- a/src/docker_bin/wo_docker_run
+++ b/src/docker_bin/wo_docker_run
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -e
+
+## Argument checks.
+for arg in "$@"; do
+    if [ "$arg" = "--detach" ] || [ "$arg" = "-d" ]; then
+        echo "Should not give '--detach' argument to $0" >&2
+        exit 1
+    fi
+    if [ "$arg" = "--rm" ]; then
+        echo "Should not give '--rm' argument to $0" >&2
+        exit 1
+    fi
+done
+if [ "$SLURM_JOB_ID" = "" ]; then
+    echo "Can not find SLURM_JOB_ID environment variable" >&2
+    exit 1
+fi
+
+## Start running the container in detach mode.
+## Also use --pid=host for protecting mental health.
+WO_CONTAINER_NAME=`docker run -d --pid host $@`
+
+## Get the container PID
+WO_CONTAINER_PID=`docker inspect -f '{{ .State.Pid }}' $WO_DOCKER_CONTAINER_NAME`
+
+
+## There is a chance that $WO_CONTAINER_PID is zero if the
+## container has stopped before `docker inspect`, in this case,
+## we do not need cgclassify.
+if [ "$WO_CONTAINER_PID" != 0 ]; then
+    ## Classify the container process (and all of it's children)
+    ## to the Slurm's cgroups assigned to the job
+ 
+    # Set the container process free from the docker cgroups
+    cgclassify -g blkio,net_cls,devices,cpuacct,cpu:/ $WO_CONTAINER_PID
+
+    # Include the container process in the Slurm cgroups
+    cgclassify -g memory,cpuset,freezer:/slurm/uid_$UID/job_$SLURM_JOB_ID/step_batch $WO_CONTAINER_PID
+
+    ## Do the same with the child processes
+    cgclassify -g blkio,net_cls,devices,cpuacct,cpu:/                                $(pgrep -P $WO_CONTAINER_PID)
+    cgclassify -g memory,cpuset,freezer:/slurm/uid_$UID/job_$SLURM_JOB_ID/step_batch $(pgrep -P $WO_CONTAINER_PID)
+fi
+
+## Wait for the container
+docker wait $WO_CONTAINER_NAME
+
+## Output the logs
+docker logs $WO_CONTAINER_NAME
+
+## Finally remove the container
+docker rm $WO_CONTAINER_NAME

--- a/src/provision_server.py
+++ b/src/provision_server.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
 
 	# scripts
 	subprocess.check_call(
-	  "cp {CPR}/src/* /mnt/nfs/clust_scripts".format(CPR = shlex.quote(CLUST_PROV_ROOT)),
+	  "cp -r {CPR}/src/* /mnt/nfs/clust_scripts".format(CPR = shlex.quote(CLUST_PROV_ROOT)),
 	  shell = True
 	)
 

--- a/src/provision_worker_container_host.sh
+++ b/src/provision_worker_container_host.sh
@@ -6,7 +6,7 @@ set -e
 /usr/local/share/slurm_gcp_docker/src/nfs_provision_worker.sh ${1}-nfs
 
 # start Slurm docker
-docker run -dti --rm --network host -v /mnt/nfs:/mnt/nfs -v /sys/fs/cgroup:/sys/fs/cgroup \
+docker run -dti --rm --pid host --network host -v /mnt/nfs:/mnt/nfs -v /sys/fs/cgroup:/sys/fs/cgroup \
   -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker \
   -v /etc/gcloud:/etc/gcloud \
   --entrypoint /usr/local/share/slurm_gcp_docker/src/docker_entrypoint_worker.sh --name slurm \


### PR DESCRIPTION
`wo_docker_run` should be able to use in place of `docker run` inside of the wolf script. It will assign the container process and its children to Slurm's cgroups using `cgclassify`.

A`--pid=host` option is added in order for `cgclassify` to work correctly across host's and container's namespace.