### PR TITLE
Upgrade ubuntu and add nonpreemptible partition

### DIFF
--- a/src/Dockerfile_base
+++ b/src/Dockerfile_base
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10 as build
+FROM ubuntu:20.04 as build
 
 WORKDIR /tmp
 
@@ -7,6 +7,8 @@ WORKDIR /tmp
 
 # 1. prereqs from apt
 RUN apt-get update && \
+DEBIAN_FRONTEND=noninteractive \
+apt-get -y install --no-install-recommends tzdata && \
 apt-get -y install build-essential vim git python3-pip \
   nfs-common portmap libmariadb-dev mariadb-client mariadb-server \
   munge libmunge-dev libhwloc-dev cgroup-tools libreadline-dev ssed wget sudo curl

--- a/src/provision_server.py
+++ b/src/provision_server.py
@@ -108,6 +108,7 @@ if __name__ == "__main__":
 	C["NodeName1"] = "{HN}-worker[101-2000] CPUs=1 RealMemory=3000 State=CLOUD Weight=2".format(HN = ctrl_hostname)
 	C["NodeName4"] = "{HN}-worker[2001-3000] CPUs=4 RealMemory=23000 State=CLOUD Weight=4".format(HN = ctrl_hostname)
 	C["NodeName88"] = "{HN}-worker[3001-3500] CPUs=8 RealMemory=50000 State=CLOUD Weight=4".format(HN = ctrl_hostname)
+	C["NodeName89"] = "{HN}-worker[3501-3600] CPUs=8 RealMemory=50000 State=CLOUD Weight=4".format(HN = ctrl_hostname) # non-preemptible
 	C["NodeName99"] = "{HN}-nfs CPUs=4 RealMemory=14000 Weight=1".format(HN = ctrl_hostname)
 
 	# partition definitions
@@ -116,10 +117,16 @@ if __name__ == "__main__":
 	C["PartitionName1"] = "n1-standard-1 Nodes={HN}-worker[101-2000]".format(HN = ctrl_hostname)
 	C["PartitionName4"] = "n1-highmem-4 Nodes={HN}-worker[2001-3000]".format(HN = ctrl_hostname)
 	C["PartitionName88"] = "n1-highmem-8 Nodes={HN}-worker[3001-3500]".format(HN = ctrl_hostname)
+	C["PartitionName89"] = "n1-highmem-8 Nodes={HN}-worker[3501-3600]".format(HN = ctrl_hostname)
 	C["PartitionName99"] = "nfs Nodes={HN}-nfs".format(HN = ctrl_hostname)
-	C["PartitionName999"] = "all Nodes={HN}-nfs,{HN}-worker[1-3500] Default=YES".format(HN = ctrl_hostname)
+	C["PartitionName888"] = "default Nodes={HN}-nfs,{HN}-worker[1-3500] Default=YES".format(HN = ctrl_hostname) # Default partition, preemptible
+	C["PartitionName889"] = "nonpreemptible Nodes={HN}-worker[3501-3600] Default=NO".format(HN = ctrl_hostname) # Non-preemptible partition
+	C["PartitionName999"] = "all Nodes={HN}-nfs,{HN}-worker[1-3600] Default=NO".format(HN = ctrl_hostname)
 
 	print_conf(C, "/mnt/nfs/clust_conf/slurm/slurm.conf")
+
+        nonstandardparts = ["all", "default", "nonpreemptible"]
+        nonpreemptible_range = range(3501, 3600 + 1)
 
 	#
 	# save node lookup table
@@ -128,11 +135,11 @@ if __name__ == "__main__":
 	  [{ "partition" : x[0], **{y[0] : y[1] for y in [z.split("=") for z in x[1:]]}} for x in parts]
 	)
 	parts = parsein(parts, "Nodes", r"(.*)\[(\d+)-(\d+)\]", ["prefix", "start", "end"])
-	parts = parts.loc[~parts["start"].isna() & (parts["partition"] != "all")].astype({ "start" : int, "end" : int })
+	parts = parts.loc[~parts["start"].isna() & (~parts["partition"].isin(nonstandardparts))].astype({ "start" : int, "end" : int })
 
 	nodes = []
 	for part in parts.itertuples():
-		nodes.append(pd.DataFrame([[part.partition, part.prefix + str(x)] for x in range(part.start, part.end + 1)], columns = ["machine_type", "idx"]))
+		nodes.append(pd.DataFrame([[part.partition, False if x in nonpreemptible_range else True, part.prefix + str(x)] for x in range(part.start, part.end + 1)], columns = ["machine_type", "preemptible", "idx"]))
 	nodes = pd.concat(nodes).set_index("idx")
 
 	nodes.to_pickle("/mnt/nfs/clust_conf/slurm/host_LuT.pickle")


### PR DESCRIPTION
This PR contains two changes:

1. Upgrade to Ubuntu 20.04 LTS as base docker. Mirrors of ubuntu 19.10 are gone and `apt-get` is no longer working.
2. Add a nonpreemptible partition as mentioned in https://github.com/getzlab/wolF/pull/47