### PR TITLE
remote provision script

### DIFF
--- a/src/Dockerfile_base
+++ b/src/Dockerfile_base
@@ -18,9 +18,9 @@ RUN ln -s /usr/bin/python3 /usr/bin/python && \
 mkdir -p /mnt/nfs
 
 # 3. build Slurm
-RUN wget https://download.schedmd.com/slurm/slurm-19.05.3-2.tar.bz2 && \
-tar xjf slurm-19.05.3-2.tar.bz2 && \
-cd slurm-19.05.3-2 && \
+RUN wget https://download.schedmd.com/slurm/slurm-20.11.7.tar.bz2 && \
+tar xjf slurm-20.11.7.tar.bz2 && \
+cd slurm-20.11.7 && \
 ./configure --prefix=/usr/local --sysconfdir=/usr/local/etc \
   --with-mysql_config=/usr/bin --with-hdf5=no && \
 make && make install

--- a/src/Dockerfile_base
+++ b/src/Dockerfile_base
@@ -15,7 +15,6 @@ apt-get -y install build-essential vim git python3-pip \
 
 # 2. convenient symlinks; NFS mount folder
 RUN ln -s /usr/bin/python3 /usr/bin/python && \
-ln -s /usr/bin/pip3 /usr/bin/pip && \
 mkdir -p /mnt/nfs
 
 # 3. build Slurm
@@ -41,7 +40,7 @@ mysql -u root -e "grant all on slurm_acct_db.* TO 'slurm'@'localhost';"
 RUN dd if=/dev/zero bs=1 count=1024 of=/etc/munge/munge.key
 
 # 7. Python prereqs
-RUN pip install pandas crcmod
+RUN pip3 install pandas crcmod
 
 # 8. install gcloud
 RUN mkdir /gcsdk && \

--- a/src/install_service.py
+++ b/src/install_service.py
@@ -6,11 +6,13 @@ services_dir = os.path.join(os.path.dirname(__file__), "services")
 
 prefectserver = os.path.join(services_dir, "prefectserver.service")
 caninebackend = os.path.join(services_dir, "caninebackend.service")
+jupyternotebook = os.path.join(services_dir, "jupyternotebook.service")
 
 def main():
     subprocess.check_call(["sudo", "cp", prefectserver, "/etc/systemd/system/prefectserver.service"])
     subprocess.check_call(["mkdir", "-p", os.path.expanduser("~/.config/systemd/user")])
     subprocess.check_call(["cp", caninebackend, os.path.expanduser("~/.config/systemd/user/caninebackend.service")])
+    subprocess.check_call(["cp", jupyternotebook, os.path.expanduser("~/.config/systemd/user/jupyternotebook.service")])
 
     subprocess.check_call(["mkdir", "-p", os.path.expanduser("~/.prefect")])
     with open(os.path.expanduser("~/.prefect/backend.toml"), "w") as f:

--- a/src/services/jupyternotebook.service
+++ b/src/services/jupyternotebook.service
@@ -1,0 +1,20 @@
+# Install to ~/.config/systemd/user/jupyternotebook.service
+[Unit]
+Description=An interactive python notebook server
+After=network.target
+
+[Service]
+# This is unsafe, but GCP blocks these ports by default.
+ExecStart=/usr/bin/jupyter notebook \
+    --no-browser \
+    --port=8082 \
+    --notebook-dir=~/ \
+    --ip='*' \
+    --NotebookApp.token='' \
+    --NotebookApp.password=''
+Restart=no
+PrivateTmp=true
+ProtectSystem=true
+
+[Install]
+WantedBy=multi-user.target

--- a/src/setup_remote.py
+++ b/src/setup_remote.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+import subprocess, os, sys, re, time
+
+this_dir = os.path.dirname(__file__)
+SLURM_GCP_DOCKER_DIR = os.path.realpath(os.path.join(this_dir, ".."))
+
+def download_getzlab_ssh_key():
+    pubkey = os.path.join(SLURM_GCP_DOCKER_DIR, "getzlabkey.pub")
+    seckey = os.path.join(SLURM_GCP_DOCKER_DIR, "getzlabkey")
+    if not os.path.exists(pubkey):
+        subprocess.check_call(["gsutil", "cp", "gs://getzlab-secrets/github-service-account/github.pub", pubkey])
+    if not os.path.exists(seckey):
+        subprocess.check_call(["gsutil", "cp", "gs://getzlab-secrets/github-service-account/github", seckey])
+
+def get_current_project():
+    ## Assuming on a GCE instance
+    project = subprocess.check_output(
+        "curl -s -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/project/project-id",
+        shell=True
+    )
+    project = project.decode()
+    return project
+
+def get_current_instance_name():
+    name = subprocess.check_output(
+        "curl -s -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/name",
+        shell=True
+    )
+    name = name.decode()
+    return name
+
+def get_current_zone():
+    ## Assuming on a GCE instance
+    zone = subprocess.check_output(
+        "curl -s -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/zone",
+        shell=True
+    )
+    zone = zone.decode()
+    zone = re.sub(".*/", "", zone)
+    return zone
+
+def create_instance(instance_name, project=None, zone=None, machine_type="n1-standard-4", boot_disk_size=200):
+    if project is None:
+        project = get_current_project()
+    if zone is None:
+        zone = get_current_zone()
+    ## I used "enable-oslogin=TRUE", which ensures consistent UID within a project.
+    subprocess.check_call(
+        f"gcloud compute instances create {instance_name} \
+            --quiet \
+            --project {project} \
+            --zone {zone} \
+            --machine-type {machine_type} \
+            --image ubuntu-minimal-2004-focal-v20210511 \
+            --image-project ubuntu-os-cloud \
+            --boot-disk-size {boot_disk_size}GB \
+            --boot-disk-type pd-standard \
+            --metadata=enable-oslogin=TRUE \
+            --scopes cloud-platform,compute-rw"
+            #--metadata-from-file startup-script={startup_script},shutdown-script={shutdown_script} \
+            , shell=True
+    )
+
+    ## Waiting for ssh working
+    n = 0
+    while True:
+        time.sleep(6)
+        try:
+            subprocess.check_call(f"gcloud compute ssh --project {project} --quiet {instance_name} --zone {zone} --command 'true'", shell=True, stderr=subprocess.DEVNULL)
+            break
+        except Exception as err:
+            if n >= 5:
+                raise err
+            pass
+        finally:
+            n += 1
+
+    ## Copy stuff and run user script
+    subprocess.check_call(
+        f"gcloud compute scp {SLURM_GCP_DOCKER_DIR}/ {instance_name}:slurm_gcp_docker --zone {zone} --recurse --project {project} --quiet --scp-flag='-q'", shell=True
+    )
+
+    ## Execute setup script
+    subprocess.check_call(
+        f'gcloud compute ssh {instance_name} --zone {zone} --project {project} -- -o "StrictHostKeyChecking no" -o "UserKnownHostsFile /dev/null" -T "bash ~/slurm_gcp_docker/src/setup_remote_user_startup_script.sh"', shell=True
+    )
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", type=str)
+    parser.add_argument("--zone", type=str)
+    parser.add_argument("instance_name", type=str)
+    parser.add_argument("--machine-type", type=str, default="n1-standard-4")
+    parser.add_argument("--boot-disk-size", type=int, default=200)
+    args = parser.parse_args()
+    download_getzlab_ssh_key()
+    create_instance(args.instance_name, project=args.project, zone=args.zone, machine_type=args.machine_type, boot_disk_size=args.boot_disk_size)
+
+if __name__ == "__main__":
+    main()

--- a/src/setup_remote_user_startup_script.sh
+++ b/src/setup_remote_user_startup_script.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -x
+
+cd ~
+
+if ! [ -f /.startup ]; then
+    ## dependencies
+    set -e
+
+    sudo apt-get -qq update
+    sudo apt-get -qq -y install nfs-common docker.io python3-pip nfs-kernel-server git
+    sudo pip3 install docker-compose google-crc32c
+
+    echo '* hard nofile 6400' | sudo tee -a /etc/security/limits.conf > /dev/null
+    echo '* soft nofile 6400' | sudo tee -a /etc/security/limits.conf > /dev/null
+
+    sudo groupadd docker || true
+    sudo usermod -aG docker $USER
+
+    ## enable docker experimental features
+    echo '{"experimental": true}' | sudo tee -a /etc/docker/daemon.json > /dev/null
+    sudo systemctl restart docker
+
+    sudo chmod 777 /var/run/docker.sock ## won't work after reboot
+
+    ## jupyter notebook
+    sudo apt-get -qq -y install jupyter
+
+    ## wolf
+    chmod 400 ~/slurm_gcp_docker/getzlabkey
+    GIT_SSH_COMMAND='ssh -i ~/slurm_gcp_docker/getzlabkey -o IdentitiesOnly=yes -o StrictHostKeyChecking=no' git clone git@github.com:getzlab/wolF.git ~/wolF
+    GIT_SSH_COMMAND='ssh -i ~/slurm_gcp_docker/getzlabkey -o IdentitiesOnly=yes -o StrictHostKeyChecking=no' git clone git@github.com:getzlab/canine.git ~/canine
+
+    (cd ~/canine && git checkout master && sudo pip3 install .)
+    (cd ~/wolF && git checkout master && sudo pip3 install .)
+
+    ## auth ssh key
+    mkdir -p ~/.ssh
+    cat ~/slurm_gcp_docker/getzlabkey.pub >> ~/.ssh/authorized_keys
+
+    ## systemd user units will stop after log-out, this avoids that.
+    sudo loginctl enable-linger $USER
+
+    ## install systemd units
+    (cd ~/slurm_gcp_docker/src && python3 install_service.py)
+
+    ## start prefect server and jupyter notebook
+    sudo systemctl start prefectserver          # port 8080 and 4200
+    sudo systemctl enable prefectserver
+    systemctl start --user jupyternotebook # port 8082
+    systemctl enable --user jupyternotebook
+
+    ## vs code
+    curl -fsSL https://code-server.dev/install.sh | sh
+    mkdir -p ~/.config/code-server
+    echo 'bind-addr: 127.0.0.1:8081' > ~/.config/code-server/config.yaml
+    echo 'auth: none'                >> ~/.config/code-server/config.yaml
+    echo 'cert: false'               >> ~/.config/code-server/config.yaml
+
+    sudo systemctl enable --now code-server@$USER
+
+    set +e
+fi
+
+sudo touch /.startup


### PR DESCRIPTION
Added a `setup_remote.py` script for spinning up a controller node, which includes a jupyter notebook server, prefect server and vscode editor. I used "enable-oslogin=TRUE", which ensures consistent UID across a project, so we only need one slurm_docker image in one project.

Things still need to be integrated:
- starts with a specific NFS disk and autoresize daemon
- a jupyter notebook template for running workflow
- forwarding ports to a central server, so that we can easily use the notebooks without doing local port forwarding?